### PR TITLE
fix(constants): add relay_log_info_file to REMOVED_SYS_VARS_84

### DIFF
--- a/src/scripts/__tests__/rules.test.ts
+++ b/src/scripts/__tests__/rules.test.ts
@@ -69,24 +69,14 @@ describe('Removed System Variables Rules', () => {
     expect(testPatternMatch('removed_sys_var', 'max_connections=100')).toBe(false);
   });
 
-  it('should detect all removed system variables', () => {
-    // Test a sample of removed variables
-    const sampleVars = [
-      'avoid_temporal_upgrade',
-      'binlog_transaction_dependency_tracking',
-      'expire_logs_days',
-      'innodb_log_file_size',
-      'innodb_log_files_in_group',
-      'keyring_file_data',
-      'language',
-      'log_bin_use_v1_row_events',
-      'old',
-      'new',
-      'show_old_temporals'
-    ];
-
-    for (const varName of sampleVars) {
-      expect(testPatternMatch('removed_sys_var', `${varName}=value`)).toBe(true);
+  it('should detect all removed system variables (exhaustive)', () => {
+    // Iterate ALL entries in REMOVED_SYS_VARS_84 so that any typo or accidental
+    // deletion of an entry causes this test to fail immediately.
+    for (const varName of REMOVED_SYS_VARS_84) {
+      expect(
+        testPatternMatch('removed_sys_var', `${varName}=value`),
+        `Expected removed_sys_var rule to detect: ${varName}`
+      ).toBe(true);
     }
   });
 

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -49,6 +49,7 @@ export const REMOVED_SYS_VARS_84 = [
   'new',
   'old',
   'old_style_user_limits',
+  'relay_log_info_file',
   'relay_log_info_repository',
   'show_old_temporals',
   'slave_rows_search_algorithms',


### PR DESCRIPTION
## Summary
- `relay_log_info_file` 시스템 변수를 `REMOVED_SYS_VARS_84` 배열에 추가
- MySQL 8.3.0에서 제거된 변수로, 공식 MySQL 8.4 문서에서 확인됨
- 교차 프로젝트 분석(tunnelforge 비교)에서 발견된 누락 항목

## Verification
- MySQL 8.4 공식 문서 (added-deprecated-removed.html) 검증 완료
- TypeScript 빌드 검증 통과 (`npx tsc --noEmit`)

## Note
원래 이슈에서 제안된 ~30개 replication/keyring 변수 중, 공식 MySQL 8.4 문서에서 실제로 제거 확인된 것은 `relay_log_info_file` 1개뿐입니다. 나머지는 deprecated 상태이거나 서드파티 가이드에서만 언급된 항목입니다.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)