### PR TITLE
fix(constants): correct SYS_VARS_NEW_DEFAULTS_84 entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Identifies system variables with changed defaults that may affect application be
 | `innodb_flush_method` | fsync | O_DIRECT | I/O optimization |
 | `innodb_io_capacity` | 200 | 10000 | SSD-optimized default |
 | `innodb_change_buffering` | all | none | Simplified change buffer |
+| `group_replication_consistency` | EVENTUAL | BEFORE_ON_PRIMARY_FAILOVER | Group Replication transaction consistency |
 
 ### 3. Authentication & Privileges
 

--- a/src/scripts/__tests__/rules.test.ts
+++ b/src/scripts/__tests__/rules.test.ts
@@ -8,6 +8,7 @@ import { compatibilityRules, rulesByCategory } from '../rules';
 import {
   REMOVED_SYS_VARS_84,
   SYS_VARS_NEW_DEFAULTS_84,
+  SYSVAR_CHECK_QUERY,
   NEW_RESERVED_KEYWORDS_84,
   REMOVED_FUNCTIONS_84
 } from '../constants';
@@ -1025,5 +1026,31 @@ describe('Constants Validation', () => {
     expect(REMOVED_FUNCTIONS_84.length).toBeGreaterThan(0);
     expect(REMOVED_FUNCTIONS_84).toContain('PASSWORD');
     expect(REMOVED_FUNCTIONS_84).toContain('ENCRYPT');
+  });
+});
+
+// ============================================================================
+// CONTRACT TESTS: SYS_VARS_NEW_DEFAULTS_84 and SYSVAR_CHECK_QUERY
+// ============================================================================
+
+describe('SYS_VARS_NEW_DEFAULTS_84 contract tests', () => {
+  it('should contain group_replication_consistency with correct values', () => {
+    const entry = SYS_VARS_NEW_DEFAULTS_84['group_replication_consistency'];
+    expect(entry).toBeDefined();
+    expect(entry[0]).toBe('EVENTUAL');
+    expect(entry[1]).toBe('BEFORE_ON_PRIMARY_FAILOVER');
+    expect(entry[2]).toBe('Group Replication 트랜잭션 일관성');
+  });
+
+  it('should NOT contain binlog_transaction_dependency_tracking (regression guard)', () => {
+    const keys = Object.keys(SYS_VARS_NEW_DEFAULTS_84);
+    expect(keys).not.toContain('binlog_transaction_dependency_tracking');
+  });
+
+  it('SYSVAR_CHECK_QUERY should contain all keys from SYS_VARS_NEW_DEFAULTS_84', () => {
+    const keys = Object.keys(SYS_VARS_NEW_DEFAULTS_84);
+    for (const key of keys) {
+      expect(SYSVAR_CHECK_QUERY).toContain(`'${key}'`);
+    }
   });
 });

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -72,7 +72,7 @@ export const SYS_VARS_NEW_DEFAULTS_84 = {
   'innodb_log_buffer_size': [16777216, 67108864, '로그 버퍼 크기'],
   'innodb_redo_log_capacity': [104857600, 419430400, 'Redo 로그 용량'],
   'innodb_change_buffering': ['all', 'none', 'Change Buffering'],
-  'binlog_transaction_dependency_tracking': ['COMMIT_ORDER', 'WRITESET', '트랜잭션 의존성 추적']
+  'group_replication_consistency': ['EVENTUAL', 'BEFORE_ON_PRIMARY_FAILOVER', 'Group Replication 트랜잭션 일관성']
 } as const;
 
 // ============================================================================
@@ -394,7 +394,7 @@ WHERE VARIABLE_NAME IN (
   'innodb_log_buffer_size',
   'innodb_redo_log_capacity',
   'innodb_change_buffering',
-  'binlog_transaction_dependency_tracking'
+  'group_replication_consistency'
 );`;
 
 // ============================================================================

--- a/src/scripts/constants.ts
+++ b/src/scripts/constants.ts
@@ -385,16 +385,7 @@ SELECT
   VARIABLE_VALUE
 FROM performance_schema.global_variables
 WHERE VARIABLE_NAME IN (
-  'replica_parallel_workers',
-  'innodb_adaptive_hash_index',
-  'innodb_doublewrite_pages',
-  'innodb_flush_method',
-  'innodb_io_capacity',
-  'innodb_io_capacity_max',
-  'innodb_log_buffer_size',
-  'innodb_redo_log_capacity',
-  'innodb_change_buffering',
-  'group_replication_consistency'
+${Object.keys(SYS_VARS_NEW_DEFAULTS_84).map(k => `  '${k}'`).join(',\n')}
 );`;
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- `binlog_transaction_dependency_tracking`을 `SYS_VARS_NEW_DEFAULTS_84`에서 제거 (이미 `REMOVED_SYS_VARS_84`에 존재, 중복 분류)
- `group_replication_consistency` 추가 (`EVENTUAL` → `BEFORE_ON_PRIMARY_FAILOVER`, MySQL 8.4 공식 문서 확인)
- `SYSVAR_CHECK_QUERY` 템플릿도 동일하게 업데이트

## Verification
- MySQL 8.4 공식 문서에서 `group_replication_consistency` 기본값 변경 확인
- `explicit_defaults_for_timestamp`는 MySQL 8.0.2 변경사항이므로 8.4 전용 목록에 불필요 → 스킵
- TypeScript 빌드 검증 통과

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)